### PR TITLE
Add ability to redact params and headers

### DIFF
--- a/src/ring/logger.clj
+++ b/src/ring/logger.clj
@@ -50,6 +50,8 @@
                the messages. A :no-color printer is provided.
     * timing: Log the time taken by the app handler? Defaults to true.
     * exceptions: Catch, log & rethrow exceptions. Defaults to true
+    * redact-fn: Function used to redact headers and params.
+                 See logger.messages/redact-some for an example
 
   The actual logging is done by the multimethods in the messages ns.
 

--- a/src/ring/logger/messages.clj
+++ b/src/ring/logger/messages.clj
@@ -1,5 +1,6 @@
 (ns ring.logger.messages
   (:require [clansi.core :as ansi]
+            [clojure.walk :as walk]
             [ring.logger.protocols :refer [debug error info trace]]))
 
 (defn get-printer
@@ -8,13 +9,24 @@
 
 (defmulti starting get-printer)
 
+(defn redact-some
+  "Creates a function that will redact each key from keys found at any nesting
+  level in m.
+  The redacted value is obtained by applying redact-fn to key and value"
+  [keys redact-fn]
+  (let [f (fn [[k v]] (if (keys k) [k (redact-fn k v)] [k v]))]
+    (fn [m]
+      (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
+
+(defn- redact-map [m {:keys [redact-fn]}]
+  (if redact-fn (redact-fn m) m))
+
 (defn- make-default-starting-message
-  [options {:keys [request-method uri remote-addr query-string headers params] :as req}]
-  (let [headers (dissoc headers "authorization")]
-    (str request-method " "
-         uri (if query-string (str "?" query-string))
-         " for " remote-addr
-         " " headers)))
+  [options {:keys [request-method uri remote-addr query-string headers] :as req}]
+  (str request-method " "
+       uri (if query-string (str "?" query-string))
+       " for " remote-addr
+       " " (pr-str (redact-map headers options))))
 
 (defmethod starting :default
   [{:keys [logger] :as options} req]
@@ -41,12 +53,15 @@
                                                     :server-port
                                                     :uri]))))
 
+(def request-params-default-prefix "  \\ - - - -  Params: ")
+
 (defmulti request-params get-printer)
 
 (defmethod request-params :default
-  [{:keys [logger]} {:keys [params]}]
+  [{:keys [logger] :as options} {:keys [params]}]
   (when params
-    (info logger (str "  \\ - - - -  Params: " params))))
+    (let [redacted-params (redact-map params options)]
+      (info logger (str request-params-default-prefix redacted-params)))))
 
 (defmulti sending-response get-printer)
 

--- a/src/ring/logger/messages.clj
+++ b/src/ring/logger/messages.clj
@@ -13,8 +13,8 @@
   "Creates a function that will redact each key from keys found at any nesting
   level in m.
   The redacted value is obtained by applying redact-fn to key and value"
-  [keys redact-fn]
-  (let [f (fn [[k v]] (if (keys k) [k (redact-fn k v)] [k v]))]
+  [keys redact-value-fn]
+  (let [f (fn [[k v]] (if (keys k) [k (redact-value-fn k v)] [k v]))]
     (fn [m]
       (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m))))
 

--- a/test/ring/logger/messages_test.clj
+++ b/test/ring/logger/messages_test.clj
@@ -1,0 +1,26 @@
+(ns ring.logger.messages-test
+  (:require [ring.logger.messages :as msg]
+            [ring.logger.protocols :refer [Logger]]
+            [clojure.edn :as edn]
+            [clojure.test :refer [is deftest]]))
+
+(deftest redacted-headers-and-params-test
+  (let [options {:printer :no-color
+                 :logger (reify Logger (log [_ _ _ message] message))
+                 :redact-fn (msg/redact-some #{:authorization :password} (constantly "[I WAS REDACTED]"))}
+        request {:request-method "GET"
+                 :uri "http://example.com/some/endpoint"
+                 :remote-addr "172.243.12.12"
+                 :query-string "some=query&string"
+                 :headers {:authorization "Basic my-fancy-encoded-secret"}
+                 :params {:password "1234"
+                          :user "nick"
+                          :foo :bar}}
+        starting-msg (msg/starting options request)
+        logged-params (msg/request-params options request)]
+    (is (.endsWith starting-msg
+                   (pr-str {:authorization "[I WAS REDACTED]"})))
+    (is (= {:password "[I WAS REDACTED]"
+            :user "nick"
+            :foo :bar} 
+           (edn/read-string (subs logged-params (count msg/request-params-default-prefix)))))))


### PR DESCRIPTION
Partial implementation of #13 (what's missing: include defaults or documentation for known auth libraries like friend, buddy, etc)
