### PR TITLE
Redact cookies too

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,15 @@ This is especially useful in case of using ring.middleware.stacktrace already.
 
 ## Password: "[REDACTED]"
 
-Sensitive information in params and headers can be redacted before it's sent to the logs.
+Sensitive information in params and headers can be redacted before it's sent to
+the logs.
 
-**This is very important**: Nobody wants user passwords or authentication tokens to get to the logs and
-live there forever, in plain text, *right*?
+**This is very important**: Nobody wants user passwords or authentication
+tokens to get to the logs and live there forever, in plain text, *right*?
 
-By default, ring-logger will redact an authorization header or any param named `password` (at any nesting level).
-If you want ring-logger to redact other params you can configure the `redact-keys` option:
+By default, ring-logger will redact the authorization and cookie header, or
+any param named `password` (at any nesting level). If you want ring-logger to
+redact other params you can configure the `redact-keys` option:
 
 ```clojure
 (wrap-with-logger app {:redact-keys #{:senha :token})

--- a/src/ring/logger.clj
+++ b/src/ring/logger.clj
@@ -39,6 +39,7 @@
        handler))
 
 (defn make-options [options]
+  {:pre [(every? keyword? (:redact-keys options))]}
   (let [logger (or (:logger options) (make-tools-logging-logger))
         redact-keys (or (:redact-keys options) #{:authorization :password :cookie :Set-Cookie})
         redact-value (or (:redact-value options) "[REDACTED]")
@@ -65,7 +66,7 @@
                  Default: logger.messages/redact-some built from :redact-keys &
                  :redact-value options
     * redact-keys: Key set passed to build the default redact-fn. Ignored if :redact-fn
-                   is present. Default: #{\"authorization\" :password}
+                   is present. Default: #{:authorization :password :cookie :Set-Cookie}
     * redact-value: Value used as the replacement for redacted keys. It's passed to build
                     the default redact-fn as `(constantly redact-value)`
 

--- a/src/ring/logger.clj
+++ b/src/ring/logger.clj
@@ -40,7 +40,7 @@
 
 (defn make-options [options]
   (let [logger (or (:logger options) (make-tools-logging-logger))
-        redact-keys (or (:redact-keys options) #{"authorization" :password})
+        redact-keys (or (:redact-keys options) #{:authorization :password :cookie :Set-Cookie})
         redact-value (or (:redact-value options) "[REDACTED]")
         redact-fn (or (:redact-fn options) (messages/redact-some redact-keys (constantly redact-value)))]
     (merge {:logger logger

--- a/test/ring/logger/messages_test.clj
+++ b/test/ring/logger/messages_test.clj
@@ -1,5 +1,6 @@
 (ns ring.logger.messages-test
-  (:require [ring.logger.messages :as msg]
+  (:require [clojure.string :as string]
+            [ring.logger.messages :as msg]
             [ring.logger :as logger]
             [ring.logger.protocols :refer [Logger]]
             [clojure.edn :as edn]
@@ -11,11 +12,11 @@
           m {"authorization" "some-secret-token"
              :password      "123456"
              :user          "john"}]
-      (is (= ((msg/redact-some #{"authorization" :password} (constantly "[REDACTED]")) m)
-             ((:redact-fn options) m)
-             {"authorization" "[REDACTED]"
+      (is (= {"authorization" "[REDACTED]"
               :password      "[REDACTED]"
-              :user          "john"}))))
+              :user          "john"}
+             ((msg/redact-some #{:authorization :password} (constantly "[REDACTED]")) m)
+             ((:redact-fn options) m)))))
 
   (testing "identity as redact-fn"
     (let [options (logger/make-options {:redact-fn identity})
@@ -30,29 +31,41 @@
         m {"authorization" "some-secret-token"
            :password      "123456"
            :user          "john"}]
-    (is (= ((msg/redact-some #{"authorization" :password} (constantly "[REDACTED]")) m)
-           ((:redact-fn options) m)
-           {"authorization" "[REDACTED]"
+    (is (= {"authorization" "[REDACTED]"
             :password      "[REDACTED]"
-            :user          "john"}))))
+            :user          "john"}
+           ((msg/redact-some #{:authorization :password} (constantly "[REDACTED]")) m)
+           ((:redact-fn options) m)))))
 
 (deftest redacted-headers-and-params-with-custom-fn-test
   (let [options {:printer :no-color
                  :logger (reify Logger (log [_ _ _ message] message))
-                 :redact-fn (msg/redact-some #{:authorization :password} (constantly "[I WAS REDACTED]"))}
+                 :redact-fn (msg/redact-some #{:authorization :cookie :password} (constantly "[I WAS REDACTED]"))}
         request {:request-method "GET"
                  :uri "http://example.com/some/endpoint"
                  :remote-addr "172.243.12.12"
                  :query-string "some=query&string"
-                 :headers {:authorization "Basic my-fancy-encoded-secret"}
+                 :headers {:authorization "Basic my-fancy-encoded-secret"
+                           :cookie "password=password-in-cookie; user=me"}
+                 :cookies {:password {:value "password-in-cookie"}
+                           :user {:value "me"}}
                  :params {:password "1234"
                           :user "nick"
                           :foo :bar}}
         starting-msg (msg/starting options request)
         logged-params (msg/request-params options request)]
-    (is (.endsWith starting-msg
-                   (pr-str {:authorization "[I WAS REDACTED]"})))
+    (let [headers-in-msg (->> starting-msg
+                             (drop-while #(not= % \{))
+                             (apply str)
+                             edn/read-string)]
+      (is (= headers-in-msg
+             {:authorization "[I WAS REDACTED]"
+              :cookie "[I WAS REDACTED]"})))
     (is (= {:password "[I WAS REDACTED]"
             :user "nick"
-            :foo :bar} 
+            :foo :bar}
+           (edn/read-string (subs logged-params (count msg/request-params-default-prefix)))))
+    (is (= {:password "[I WAS REDACTED]"
+            :user "nick"
+            :foo :bar}
            (edn/read-string (subs logged-params (count msg/request-params-default-prefix)))))))


### PR DESCRIPTION
Adds `:cookie` and `:Set-Cookie` to the default redacted keys set
Redacts `:headers` in response, because it could include the cookies
Adds example with cookies

Breaking change: the keys in `:redact-keys` should be all keywords now
