### PR TITLE
Remove unnecessary println line

### DIFF
--- a/src/ring/logger/messages.clj
+++ b/src/ring/logger/messages.clj
@@ -134,7 +134,6 @@
 
 (defn- redact-request [req options]
   (let [redact #(redact-map % options)]
-    (println "redacting request: " (pr-str req))
     (-> req
         (update-in [:headers] redact)
         (update-in [:params] redact)


### PR DESCRIPTION
It looks like this println should not be here and flushes failed requests to stdouterr