### PR TITLE
Remove all the request-id stuff

### DIFF
--- a/src/ring/logger.clj
+++ b/src/ring/logger.clj
@@ -4,9 +4,6 @@
   (:require
     [clojure.tools.logging :as c.t.logging]))
 
-(defn default-request-id-fn [_]
-  (rand-int 0xffffff))
-
 (defn default-log-fn [{:keys [level throwable message]}]
   (c.t.logging/log level throwable message))
 
@@ -21,41 +18,34 @@
              :or {log-fn default-log-fn
                   transform-fn identity
                   log-level :debug}}]
-   (fn [{:keys [::request-id] :as request}]
+   (fn [request]
      (let [log (make-transform-and-log-fn transform-fn log-fn)]
        (log {:level log-level
-            :message (-> (select-keys request [:request-method :uri :server-name])
-                         (assoc ::type :params
-                                :params (:params request))
-                         (cond-> request-id (assoc ::request-id request-id)))}))
+             :message (-> (select-keys request [:request-method :uri :server-name])
+                          (assoc ::type :params
+                                 :params (:params request)))}))
      (handler request))))
 
 (defn wrap-log-request
   ([handler] (wrap-log-request handler {}))
-  ([handler {:keys [request-id-fn log-fn log-exceptions? transform-fn]
-             :or {request-id-fn default-request-id-fn
-                  log-fn default-log-fn
+  ([handler {:keys [log-fn log-exceptions? transform-fn]
+             :or {log-fn default-log-fn
                   transform-fn identity
                   log-exceptions? true}}]
    (fn [request]
      (let [start-ms (System/currentTimeMillis)
-           request-id (request-id-fn request)
            log (make-transform-and-log-fn transform-fn log-fn)]
        (log {:level :info
              :message (-> (select-keys request [:request-method :uri :server-name])
-                          (assoc ::type :starting)
-                          (cond-> request-id (assoc ::request-id request-id)))})
+                          (assoc ::type :starting))})
        (try
-         (let [response (-> request
-                            (cond-> request-id (assoc ::request-id request-id))
-                            (handler))
+         (let [response (handler request)
                elapsed-ms (- (System/currentTimeMillis) start-ms)]
            (log {:level :info
                  :message (-> (select-keys request [:request-method :uri :server-name])
                               (assoc ::type :finish
                                      :status (:status response)
-                                     ::ms elapsed-ms)
-                              (cond-> request-id (assoc ::request-id request-id)))})
+                                     ::ms elapsed-ms))})
            response)
          (catch Exception e
            (when log-exceptions?
@@ -64,8 +54,7 @@
                      :throwable e
                      :message (-> (select-keys request [:request-method :uri :server-name])
                                   (assoc ::type :exception
-                                         ::ms elapsed-ms)
-                                  (cond-> request-id (assoc ::request-id request-id)))})))
+                                         ::ms elapsed-ms))})))
            (throw e)))))))
 
 (defn wrap-with-logger
@@ -78,10 +67,6 @@
               it might need to handle: [:start :params :finish :exception]. It can be
               filter messages by returning nil. Log items are maps with keys:
               [:level :throwable :message].
-    * request-id-fn: takes a request and returns a unique request id which is logged
-              and added to the request map under :ring.logger/request-id key.
-              The key is not added when the fn returns nil. Defaults
-              to `ring.logger/default-request-id-fn`.
     * log-exceptions?: When true, logs exceptions as an :error level message, rethrowing
               the original exception. Defaults to true"
   ([handler options]

--- a/test/ring/logger_test.clj
+++ b/test/ring/logger_test.clj
@@ -27,8 +27,7 @@
               (swap! output conj message))
         handler (-> ok-handler
                     wrap-params
-                    (logger/wrap-log-request {:log-fn log
-                                               :request-id-fn (constantly 42)}))
+                    (logger/wrap-log-request {:log-fn log}))
         response (-> (mock/request :get
                                    "/some/path?password=secret&email=foo@example.com")
                      (handler))
@@ -42,8 +41,7 @@
             :message {::logger/type :starting
                       :request-method :get
                       :uri "/some/path"
-                      :server-name "localhost"
-                      ::logger/request-id 42}}
+                      :server-name "localhost"}}
            start))
     (let [elapsed (-> finish :message ::logger/ms)]
       (is (= {:level :info
@@ -52,7 +50,6 @@
                         :uri "/some/path"
                         :server-name "localhost"
                         :status 200
-                        ::logger/request-id 42
                         ::logger/ms elapsed}}
              finish))
       (is (pos? elapsed)))))
@@ -89,8 +86,7 @@
         handler (-> ok-handler
                     (logger/wrap-log-params {:log-fn log})
                     wrap-params
-                    (logger/wrap-log-request {:log-fn log
-                                               :request-id-fn (constantly 42)}))
+                    (logger/wrap-log-request {:log-fn log}))
         response (-> (mock/request :get
                                    "/some/path?password=secret&email=foo@example.com")
                      (handler))
@@ -104,12 +100,10 @@
             :message {::logger/type :starting
                       :request-method :get
                       :uri "/some/path"
-                      :server-name "localhost"
-                      ::logger/request-id 42}}
+                      :server-name "localhost"}}
            start))
     (is (= {:level :debug
             :message {::logger/type :params
-                      ::logger/request-id 42
                       :request-method :get
                       :uri "/some/path"
                       :server-name "localhost"
@@ -123,7 +117,6 @@
                         :uri "/some/path"
                         :server-name "localhost"
                         :status 200
-                        ::logger/request-id 42
                         ::logger/ms elapsed}}
              finish))
       (is (pos? elapsed)))))
@@ -135,8 +128,7 @@
         handler (-> throws-handler
                     (logger/wrap-log-params {:log-fn log})
                     wrap-params
-                    (logger/wrap-log-request {:log-fn log
-                                               :request-id-fn (constantly 42)}))
+                    (logger/wrap-log-request {:log-fn log}))
         ex (try
             (-> (mock/request :get
                               "/some/path?password=secret&email=foo@example.com")
@@ -149,12 +141,10 @@
             :message {::logger/type :starting
                       :request-method :get
                       :uri "/some/path"
-                      :server-name "localhost"
-                      ::logger/request-id 42}}
+                      :server-name "localhost"}}
            start))
     (is (= {:level :debug
             :message {::logger/type :params
-                      ::logger/request-id 42
                       :request-method :get
                       :uri "/some/path"
                       :server-name "localhost"
@@ -168,7 +158,6 @@
                         :request-method :get
                         :uri "/some/path"
                         :server-name "localhost"
-                        ::logger/request-id 42
                         ::logger/ms elapsed}}
              logged-ex))
       (is (pos? elapsed)))))
@@ -178,8 +167,7 @@
         log (fn [message]
               (swap! output conj message))
         handler (-> ok-handler
-                    (logger/wrap-with-logger {:log-fn log
-                                              :request-id-fn (constantly 42)})
+                    (logger/wrap-with-logger {:log-fn log})
                     wrap-params)
         response (-> (mock/request :get
                                    "/some/path?password=secret&email=foo@example.com")
@@ -194,12 +182,10 @@
             :message {::logger/type :starting
                       :request-method :get
                       :uri "/some/path"
-                      :server-name "localhost"
-                      ::logger/request-id 42}}
+                      :server-name "localhost"}}
            start))
     (is (= {:level :debug
             :message {::logger/type :params
-                      ::logger/request-id 42
                       :request-method :get
                       :uri "/some/path"
                       :server-name "localhost"
@@ -213,7 +199,6 @@
                         :uri "/some/path"
                         :server-name "localhost"
                         :status 200
-                        ::logger/request-id 42
                         ::logger/ms elapsed}}
              finish))
       (is (pos? elapsed)))))
@@ -231,7 +216,7 @@
 
 (deftest tools-logging-test
   (let [handler (-> ok-handler
-                    (logger/wrap-with-logger {:request-id-fn (constantly 42)})
+                    logger/wrap-with-logger
                     wrap-params)
         output-str (with-system-out-str
                      (-> (mock/request :get
@@ -249,11 +234,9 @@
     (is (= {::logger/type :starting
             :request-method :get
             :uri "/some/path"
-            :server-name "localhost"
-            ::logger/request-id 42}
+            :server-name "localhost"}
            start))
     (is (= {::logger/type :params
-            ::logger/request-id 42
             :request-method :get
             :uri "/some/path"
             :server-name "localhost"
@@ -266,7 +249,6 @@
               :uri "/some/path"
               :server-name "localhost"
               :status 200
-              ::logger/request-id 42
               ::logger/ms elapsed}
              finish))
       (is (pos? elapsed)))))
@@ -281,8 +263,7 @@
                        (reset! elapsed (get-in log-item [:message ::logger/ms]))
                        (logger.compat/logger-0.7.0-transform-fn log-item))
         handler (-> ok-handler
-                    (logger/wrap-with-logger {:request-id-fn (constantly 42)
-                                              :transform-fn transform-fn
+                    (logger/wrap-with-logger {:transform-fn transform-fn
                                               :log-fn log})
                     wrap-params)
         response (-> (mock/request :get


### PR DESCRIPTION
It's not essential to ring.logger, and it could be handled by allowing to choose which keys from the request should be logged so for example one could pass `[:request-method :uri :server-name :request-id]` as a new `:request-keys` option, using a middleware to add a unique request id under the `:request-id` key.

On some other scenarios, this is handled on the logging backend, using things like log4j's ThreadContext, timbre's output-fn, etc