### PR TITLE
Status to level config

### DIFF
--- a/src/ring/logger.clj
+++ b/src/ring/logger.clj
@@ -99,26 +99,28 @@
      ([request respond raise]
       (handler (log-request-start request options) respond raise)))))
 
-(defn- log-response [{:keys [status] :as response} start-ms log base-message]
-  (let [elapsed-ms (- (System/currentTimeMillis) start-ms)
-        level (if (and (number? status)
-                       (<= 500 status))
-                :error
-                :info)]
-    (log {:level level
-          :message (-> base-message
-                       (assoc ::type :finish
-                              :status status
-                              ::ms elapsed-ms))})
-    response))
+(defn- default-status-to-log-level [status]
+  (if (and (number? status)
+           (<= 500 status))
+    :error
+    :info))
+
+(defn- log-response [{:keys [status] :as response} start-ms log base-message
+                     {:keys [status-to-log-level-fn]
+                      :or {status-to-log-level-fn default-status-to-log-level}}]
+  (log {:level (status-to-log-level-fn status)
+        :message (-> base-message
+                     (assoc ::type :finish
+                            :status status
+                            ::ms (- (System/currentTimeMillis) start-ms)))})
+  response)
 
 (defn- log-exception [ex start-ms log base-message]
-  (let [elapsed-ms (- (System/currentTimeMillis) start-ms)]
-    (log {:level :error
-          :throwable ex
-          :message (-> base-message
-                       (assoc ::type :exception
-                              ::ms elapsed-ms))})))
+  (log {:level :error
+        :throwable ex
+        :message (-> base-message
+                     (assoc ::type :exception
+                            ::ms (- (System/currentTimeMillis) start-ms)))}))
 
 (defn wrap-log-response
   "Ring middleware to log response and timing for each request.
@@ -137,13 +139,16 @@
               that ring.logger adds like [::type ::ms :status].
               Defaults to [:request-method :uri :server-name]
     * log-exceptions?: When true, logs exceptions as an :error level message, rethrowing
-              the original exception. Defaults to true"
+              the original exception. Defaults to true
+    * status-to-log-level-fn: A function that receives the response status as a number, and returns
+              the log level. By default, <= 500 are :error, rest are :info."
   ([handler] (wrap-log-response handler {}))
   ([handler {:keys [log-fn log-exceptions? transform-fn request-keys]
              :or {log-fn default-log-fn
                   transform-fn identity
                   log-exceptions? true
-                  request-keys default-request-keys}}]
+                  request-keys default-request-keys}
+             :as options}]
    (fn
      ([request]
       (let [start-ms (or (::start-ms request)
@@ -151,7 +156,7 @@
             log (make-transform-and-log-fn transform-fn log-fn)
             base-message (select-keys request request-keys)]
         (try
-          (log-response (handler request) start-ms log base-message)
+          (log-response (handler request) start-ms log base-message options)
           (catch Exception ex
             (when log-exceptions? (log-exception ex start-ms log base-message))
             (throw ex)))))
@@ -161,7 +166,7 @@
             log (make-transform-and-log-fn transform-fn log-fn)
             base-message (select-keys request request-keys)]
         (handler request
-                 (fn [response] (respond (log-response response start-ms log base-message)))
+                 (fn [response] (respond (log-response response start-ms log base-message options)))
                  (fn [ex] (when log-exceptions? (log-exception ex start-ms log base-message)) (raise ex))))))))
 
 (defn wrap-with-logger
@@ -186,7 +191,9 @@
     * redact-key?: fn that is called on each key in the params map to check whether its
               value should be redacted. Receives the key, returns truthy/falsy. A common
               pattern is to use a set.
-              Default value: #{:authorization :password :token :secret :secret-key :secret-token}"
+              Default value: #{:authorization :password :token :secret :secret-key :secret-token}
+    * status-to-log-level-fn: A function that receives the response status as a number, and returns
+              the log level. By default, <= 500 are :error, rest are :info."
   ([handler options]
    (-> handler
        (wrap-log-response options)


### PR DESCRIPTION
Builds on top of #49 , that PR should be merged first.

This PR adds a new configuration, status-to-level-fn. It enables users to tell, what level of loggin they want for which status codes.